### PR TITLE
feat: load initial data from json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "rocket",
  "rocket_okapi",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ log4rs = "1.2.0"
 rocket = "0.5.0-rc.2"
 rocket_okapi = { version = "0.8.0-rc.2", features = ["swagger", "rapidoc"] }
 serde = "1.0.160"
+serde_json = "1.0.64"
 thiserror = "1.0.40"
 tokio = "1.28.0"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Cedar Agent configuration is available using environment variables and command l
 - The log level to filter logs. Defaults to `info`.  
   `LOG_LEVEL` environment variable.  
   `--log-level`, `-l` command line argument.
+- Load data from json file. Defaults to `None`.  
+  `DATA` environment variable.
+  `--data`, `-d` command line argument.
 
 **command line arguments take precedence over environment variables when configuring the Cedar Agent**
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub port: Option<u16>,
     #[arg(short, long, value_enum)]
     pub log_level: Option<LevelFilter>,
+    #[arg(short, long)]
+    pub data: Option<String>,
 }
 
 impl Into<rocket::figment::Figment> for &Config {
@@ -34,6 +36,9 @@ impl Into<rocket::figment::Figment> for &Config {
         } else {
             config = config.merge(("port", 8180))
         }
+        if let Some(data) = self.data.borrow() {
+            config = config.merge(("data", data));
+        }
 
         config
     }
@@ -46,6 +51,7 @@ impl Config {
             addr: None,
             port: None,
             log_level: None,
+            data: None,
         }
     }
 
@@ -56,6 +62,7 @@ impl Config {
             config.addr = c.addr.or(config.addr);
             config.port = c.port.or(config.port);
             config.log_level = c.log_level.or(config.log_level);
+            config.data = c.data.or(config.data);
         }
 
         config

--- a/src/load_data.rs
+++ b/src/load_data.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use log::{error, info};
+
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::Rocket;
+use rocket::Build;
+
+use crate::services::data::DataStore;
+use crate::config;
+use crate::schemas::data::Entities;
+
+pub struct InitDataFairing;
+
+pub(crate) async fn init(conf: &config::Config, data_store: &Box<dyn DataStore>) {
+    let file_path = conf.data.clone().unwrap_or("".to_string());
+
+    if file_path.is_empty() {
+        return;
+    }
+
+    let entities_file_path = PathBuf::from(&file_path);
+    let entities = match load_entities_from_file(entities_file_path).await {
+        Ok(entities) => entities,
+        Err(err) => {
+            error!("Failed to load entities from file: {}", err);
+            return;
+        }
+    };
+
+    match data_store.update_entities(entities).await {
+        Ok(entities) => {
+            info!("Successfully updated entities from file {}: {} entities", &file_path, entities.len());
+        }
+        Err(err) => {
+            error!("Failed to update entities: {}", err);
+            return;
+        }
+    };
+}
+
+async fn load_entities_from_file(path: PathBuf) -> Result<Entities, Box<dyn Error>> {
+    // check if file exists
+    if !path.exists() {
+        return Err("File does not exist".into());
+    }
+
+    // check if is a valid json file
+    if path.extension().unwrap() != "json" {
+        return Err("File is not a json file".into());
+    }
+
+    let mut file = File::open(&path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let entities: Entities = serde_json::from_str(&contents)?;
+    Ok(entities)
+}
+
+#[async_trait::async_trait]
+impl Fairing for InitDataFairing {
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> Result<Rocket<Build>, Rocket<Build>> {
+        let config = rocket.state::<config::Config>().unwrap();
+        init(config, rocket.state::<Box<dyn DataStore>>().unwrap()).await;
+
+        Ok(rocket)
+    }
+
+    fn info(&self) -> Info {
+        Info {
+            name: "Init Data",
+            kind: Kind::Ignite
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod logger;
 mod routes;
 mod schemas;
 mod services;
+mod load_data;
 
 #[rocket::main]
 async fn main() {
@@ -29,6 +30,7 @@ async fn main() {
     let server_config: rocket::figment::Figment = config.borrow().into();
     let launch_result = rocket::custom(server_config)
         .attach(common::DefaultContentType::new(ContentType::JSON))
+        .attach(load_data::InitDataFairing)
         .manage(config)
         .manage(Box::new(MemoryPolicyStore::new()) as Box<dyn PolicyStore>)
         .manage(Box::new(MemoryDataStore::new()) as Box<dyn DataStore>)


### PR DESCRIPTION
Use the `-d` or `--data` option and inform the path of the json file you want to load in cedar's memory, it is also possible to use a `DATA` environment variable

examples:

```bash
cargo run -- -d "./examples/data.json"
```

```bash
cargo run -- --data "./examples/data.json"
```

```bash
export DATA="./examples/data.json"
cargo run
```